### PR TITLE
Added course : AWS cloud practitioner by freeCodecamp  on Youtube

### DIFF
--- a/Online Course.json
+++ b/Online Course.json
@@ -732,6 +732,12 @@
         "platform": "scrimba",
         "courseLink": "https://scrimba.com/learn/learnreact"
     },
+    {
+        "id":"435",
+        "courseName":"AWS Cloud Practitioner",
+        "platform":"youtube",
+        "courseLink":"https://www.youtube.com/watch?v=3hLmDS179YE"
+    },
 
 ]
 


### PR DESCRIPTION
This is the course link for aws cloud practitioner training by freeCodeCamp on youtube platform for people who want to learn aws cloud and become great at it!